### PR TITLE
Uses session storage to persist table search params

### DIFF
--- a/app/frontend/Components/Table/Body.tsx
+++ b/app/frontend/Components/Table/Body.tsx
@@ -1,14 +1,17 @@
 import React, { forwardRef } from 'react'
-import { TableSectionContextProvider } from './TableContext'
+import { TableSectionContextProvider, useTableContext } from './TableContext'
 import { TBodyProps } from 'react-html-props'
-import { Box, type BoxProps } from '@mantine/core'
+import { Box, LoadingOverlay, type BoxProps } from '@mantine/core'
 
 interface ITableBody extends BoxProps, TBodyProps {}
 
 const Body = forwardRef<HTMLTableSectionElement, ITableBody>(({ children, ...props }, ref) => {
+	const { tableState: { searching } } = useTableContext()
+
 	return (
 		<TableSectionContextProvider value={ { section: 'body' } }>
 			<Box component="tbody" { ...props } ref={ ref }>
+				{ searching && <tr><td><LoadingOverlay visible={ searching } overlayBlur={ 1 } /></td></tr> }
 				{ children }
 			</Box>
 		</TableSectionContextProvider>

--- a/app/frontend/Components/Table/SearchInput/index.tsx
+++ b/app/frontend/Components/Table/SearchInput/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useEffect, useMemo } from 'react'
 import { Inertia, type VisitOptions } from '@inertiajs/inertia'
 import { debounce } from 'lodash'
 import { useTableContext } from '../TableContext'
@@ -6,6 +6,7 @@ import { TextInput } from '@/Components/Inputs'
 import { SearchIcon, CrossIcon, DoubleDownArrowIcon } from '@/Components/Icons'
 import { ActionIcon, Box } from '@mantine/core'
 import { Table } from '@/Components'
+import { useSessionStorage } from '@mantine/hooks'
 
 interface ISearchInputProps {
 	columnPicker?: boolean
@@ -20,7 +21,20 @@ const SearchInput = ({ columnPicker = true }: ISearchInputProps) => {
 	const { search } = window.location
 
 	const params = new URLSearchParams(search)
-	const [searchValue, setSearchValue] = useState(params.get('search') || '')
+	const [searchValue, setSearchValue] = useSessionStorage({
+		key: `${model}-query`,
+		defaultValue: params.get('search') || ''
+	})
+
+	useEffect(() => {
+		const urlSearchString = params.get('search')
+
+		if(urlSearchString) {
+			setSearchValue(searchValue)
+		} else if(searchValue !== '' && !urlSearchString) {
+			setSearchValue(searchValue)
+		}
+	}, [])
 
 	const debouncedSearch = useMemo(() => debounce((path) => {
 		const options: VisitOptions = {

--- a/app/frontend/Components/Table/SearchInput/index.tsx
+++ b/app/frontend/Components/Table/SearchInput/index.tsx
@@ -22,7 +22,7 @@ const SearchInput = ({ columnPicker = true }: ISearchInputProps) => {
 
 	const params = new URLSearchParams(search)
 	const [searchValue, setSearchValue] = useSessionStorage({
-		key: `${model}-query`,
+		key: `${model ?? 'standard'}-query`,
 		defaultValue: params.get('search') || ''
 	})
 
@@ -31,7 +31,8 @@ const SearchInput = ({ columnPicker = true }: ISearchInputProps) => {
 
 		if(urlSearchString) {
 			setSearchValue(urlSearchString)
-		} else if(searchValue !== '' && !urlSearchString) {
+		// Don't persist searches for tables not scoped to a model
+		} else if(model && searchValue !== '' && !urlSearchString) {
 			setSearchValue(searchValue)
 		}
 	}, [])

--- a/app/frontend/Components/Table/SearchInput/index.tsx
+++ b/app/frontend/Components/Table/SearchInput/index.tsx
@@ -30,7 +30,7 @@ const SearchInput = ({ columnPicker = true }: ISearchInputProps) => {
 		const urlSearchString = params.get('search')
 
 		if(urlSearchString) {
-			setSearchValue(searchValue)
+			setSearchValue(urlSearchString)
 		} else if(searchValue !== '' && !urlSearchString) {
 			setSearchValue(searchValue)
 		}

--- a/app/frontend/Components/Table/TableContext.tsx
+++ b/app/frontend/Components/Table/TableContext.tsx
@@ -23,6 +23,7 @@ interface ITableSettings {
 	selected: Set<string>
 	hideable: boolean
 	model?: string
+	searching: boolean
 }
 
 interface ITableContext {
@@ -63,6 +64,7 @@ const TableProvider: React.FC<ITableContextProviderProps> = ({
 		selected: new Set<string>(),
 		hideable,
 		model,
+		searching: false,
 	})
 
 	return (


### PR DESCRIPTION
Search params for tables are persisted to local storage

Visiting the root url for an index page will attempt to re-use the session's search for that table
Visiting an index page with url search params will overwrite the session's saved search params for that table